### PR TITLE
:sparkles: Feat: 헤더 컴포넌트 마크업 구현

### DIFF
--- a/src/atoms/image/Image.tsx
+++ b/src/atoms/image/Image.tsx
@@ -4,8 +4,8 @@ import styled from "styled-components";
 interface ImageProps {
   marginTop?: number;
   marginBottom?: number;
-  width: number;
-  height: number;
+  width?: number;
+  height?: number;
   src: string;
   alt: string;
 }
@@ -29,8 +29,8 @@ const Image = ({
     <Img
       marginTop={marginTop ?? marginTop}
       marginBottom={marginBottom ?? marginBottom}
-      width={width}
-      height={height}
+      width={width ?? width}
+      height={height ?? height}
       src={src}
       alt={alt}
     />

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import styled from "styled-components";
+import Image from "../../atoms/image/Image";
+
+interface HeaderProps {
+  children?: React.ReactNode;
+}
+
+const HeaderWrap = styled.div`
+  height: 48px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 20px;
+  &::after {
+    content: "";
+    display: block;
+  }
+`;
+
+const H2 = styled.h2`
+  font-size: 28px;
+  font-family: "Shinb7Regular";
+`;
+
+const Header = ({ children }: HeaderProps) => {
+  return (
+    <HeaderWrap>
+      <Image
+        width={18}
+        src="assets/icons/icon-arrow-left.svg"
+        alt="뒤로가기 버튼"
+      />
+      <H2>{children ?? children}</H2>
+    </HeaderWrap>
+  );
+};
+
+export default Header;

--- a/src/components/header/style.ts
+++ b/src/components/header/style.ts
@@ -1,0 +1,1 @@
+import styled from "styled-components";


### PR DESCRIPTION
### 무엇을 위한 PR인가요?


resolves: # 

- [x] 신규 기능 추가 :
- [ ] 기능 수정 :
- [ ] 버그 수정 :
- [ ] 기타 : 

### 변경사항 및 이유

- 헤더 컴포넌트 필요성 느껴 추가

### 작업 내역

- 헤더 컴포넌트 마크업 구현, h2필요시 태그 사이에 넣어 사용, 불필요한 경우 닫힌 태그로 작성(기본값은 뒤로가기 버튼만 존재)

### 작업 후 기대 동작(스크린샷)

<img width="392" alt="스크린샷 2022-10-10 오후 4 38 00" src="https://user-images.githubusercontent.com/94890646/194818022-4f61f414-9fc4-4d94-ac61-78bb51868ef7.png">
